### PR TITLE
workaround for watchdog timeout crashes when socket is stale

### DIFF
--- a/SuplaApp.m
+++ b/SuplaApp.m
@@ -374,8 +374,16 @@ NSString *kSAOnZWaveSetWakeUpTimeResult = @"KSA-N30";
 
 +(void) SuplaClientWaitForTerminate {
     
+    NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow: 3];
+    
     while([[self instance] SuplaClientTerminate]) {
-        [[NSRunLoop currentRunLoop] runUntilDate:[NSDate date]];
+        @autoreleasepool {
+            NSDate *cDate = [NSDate date];
+            if([cDate earlierDate: deadline] == deadline)
+                break;
+            else
+                [[NSRunLoop currentRunLoop] runUntilDate: cDate];
+        }
     }
     
 }


### PR DESCRIPTION
Don't indefinitely wait for client to terminate, but rather timeout to allow graceful
background transition.